### PR TITLE
feat: pin modules plus add logo module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+notebook/

--- a/README.md
+++ b/README.md
@@ -117,3 +117,65 @@ If using the default commiter is not good enough for you, you can create your ow
 3. **Test Your Commiter**: After implementing your commiter, test it thoroughly to ensure it works as expected with the `goodcommit` form.
 
 By following these steps, you can create and integrate your own commiter into `goodcommit`, allowing for a highly customized commit process.
+
+## Configuring Modules
+
+Modules in `goodcommit` can be customized through the a json file. This section outlines how to configure modules, detailing the available fields, their types, and functionalities.
+
+### Configuration Fields
+
+Each module configuration can include the following fields:
+
+- `name`: `string` - The unique identifier for the module.
+- `page`: `int` - Determines on which page the module appears in the form.
+- `position`: `int` (optional, default: `0`) - The order of the module on the page.
+- `pinned`: `bool` (optional, default: `false`) - If `true`, the module is pinned to the top of every page after its initial appearance.
+- `active`: `bool` (optional, default: `true`) - Controls the module's activation state. Inactive modules are not displayed.
+- `path`: `string` (optional) - Specifies a path to additional configuration or data files required by the module.
+- `priority`: `int` (optional, default: `0`) - Used to determine the module's priority. Lower values indicate higher priority.
+- `checkpoint`: `bool` (optional, default: `false`) - If `true`, the form will prompt for confirmation before proceeding past this module.
+
+### Examples
+
+Below are examples of different module configurations and their effects:
+
+1. **Basic Module Configuration**
+
+   ```json
+   {
+     "name": "description",
+     "page": 1,
+     "position": 1,
+     "pinned": false,
+     "active": true
+   }
+   ```
+   This configuration activates the `description` module, placing it first on page 1 without pinning it.
+
+2. **Pinned Module Configuration**
+
+   ```json
+   {
+     "name": "logo",
+     "page": 1,
+     "position": 1,
+     "pinned": true,
+     "active": true
+   }
+   ```
+   The `logo` module is activated, pinned, and placed at the top of every page.
+
+3. **Module with External Configuration**
+
+   ```json
+   {
+     "name": "types",
+     "page": 1,
+     "position": 2,
+     "active": true,
+     "path": "./configs/commit_types.json"
+   }
+   ```
+   Activates the `types` module, using an external file for additional configuration.
+
+By adjusting these fields in the `config.json` file, you can tailor the `goodcommit` form to meet your project's specific needs.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/nantli/goodcommit/pkg/modules/coauthors"
 	"github.com/nantli/goodcommit/pkg/modules/description"
 	"github.com/nantli/goodcommit/pkg/modules/greetings"
+	"github.com/nantli/goodcommit/pkg/modules/logo"
 	"github.com/nantli/goodcommit/pkg/modules/scopes"
 	"github.com/nantli/goodcommit/pkg/modules/types"
 	"github.com/nantli/goodcommit/pkg/modules/why"
@@ -37,6 +38,7 @@ func main() {
 
 	// Load modules
 	modules := []module.Module{
+		logo.New(),
 		greetings.New(),
 		types.New(),
 		scopes.New(),

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -1,15 +1,22 @@
 {
     "activeModules": [
         {
-            "name": "greetings",
+            "name": "logo",
             "page": 1,
             "position": 1,
+            "pinned": true,
+            "active": true
+        },
+        {
+            "name": "greetings",
+            "page": 1,
+            "position": 2,
             "active": true
         },
         {
             "name": "types",
             "page": 1,
-            "position": 2,
+            "position": 3,
             "active": true,
             "path": "./configs/commit_types.example.json",
             "checkpoint": true

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -10,6 +10,7 @@ type Config struct {
 	Path       string `json:"path,omitempty"`
 	Priority   int    `json:"priority"`
 	Checkpoint bool   `json:"checkpoint"`
+	Pinned     bool   `json:"pinned"`
 }
 
 type Item struct {

--- a/pkg/modules/breaking/breaking.go
+++ b/pkg/modules/breaking/breaking.go
@@ -21,7 +21,7 @@ func (s *Breaking) LoadConfig() error {
 func (s *Breaking) NewField(commit *module.CommitInfo) (huh.Field, error) {
 
 	return huh.NewConfirm().
-		Title("🙊・Does this commit introduce a Breaking Change?").
+		Title("☎️・Does this commit introduce a Breaking Change?").
 		Affirmative("Yes 🚨").
 		Negative("No 🏖️").
 		Value(&commit.Breaking), nil

--- a/pkg/modules/description/description.go
+++ b/pkg/modules/description/description.go
@@ -22,7 +22,7 @@ func (d *Description) LoadConfig() error {
 // NewField returns a new Input field for the user to write a brief description of the commit (max 50 chars).
 func (d *Description) NewField(commit *module.CommitInfo) (huh.Field, error) {
 	return huh.NewInput().
-		Title("🐵・Write the Commit Description").
+		Title("✏️・Write the Commit Description").
 		Description("Briefly describe the changes in this commit (max 50 chars).").
 		CharLimit(50).
 		Value(&commit.Description), nil

--- a/pkg/modules/greetings/greetings.go
+++ b/pkg/modules/greetings/greetings.go
@@ -35,8 +35,8 @@ func (g *Greetings) NewField(commit *module.CommitInfo) (huh.Field, error) {
 	}
 
 	// Display staged files as a simple text field in the form
-	stagedFilesText := fmt.Sprintf("Staged Files:\n%s", stagedFiles)
-	return huh.NewConfirm().Title("🐒・Do you want to commit these files?").Description(stagedFilesText).Validate(
+	stagedFilesText := fmt.Sprintf("\nStaged Files:\n%s", stagedFiles)
+	return huh.NewConfirm().Title("🐝・Do you want to commit these files?").Description(stagedFilesText).Validate(
 		func(b bool) error {
 			if b {
 				return nil

--- a/pkg/modules/logo/logo.go
+++ b/pkg/modules/logo/logo.go
@@ -1,0 +1,58 @@
+package logo
+
+import (
+	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/module"
+)
+
+const MODULE_NAME = "logo"
+
+type Logo struct {
+	config module.Config
+}
+
+func (l *Logo) LoadConfig() error {
+	return nil
+}
+
+func (l *Logo) NewField(commit *module.CommitInfo) (huh.Field, error) {
+	asciiArt := `                          
+		 ____ ____ ____ ____ ____ ____      
+		||N |||a |||n |||t |||l |||i ||     
+		||__|||__|||__|||__|||__|||__||     
+		|/__\|/__\|/__\|/__\|/__\|/__\|     
+	┌─────────────────────────────────────┐ 
+	│  You're gonna like this commit...   │ 
+	└─────────────────────────────────────┘ 
+	`
+	return huh.NewNote().Title(asciiArt), nil
+}
+
+func (l *Logo) PostProcess(commit *module.CommitInfo) error {
+	// No post-processing needed for the Logo module.
+	return nil
+}
+
+func (l *Logo) GetConfig() module.Config {
+	return l.config
+}
+
+func (l *Logo) SetConfig(config module.Config) {
+	l.config = config
+}
+
+func (l *Logo) GetName() string {
+	return MODULE_NAME
+}
+
+func (l *Logo) IsActive() bool {
+	return l.config.Active
+}
+
+func (l *Logo) InitCommitInfo(commit *module.CommitInfo) error {
+	return nil
+}
+
+func New() module.Module {
+	return &Logo{config: module.Config{Name: MODULE_NAME}}
+}

--- a/pkg/modules/scopes/scope.go
+++ b/pkg/modules/scopes/scope.go
@@ -53,8 +53,8 @@ func (s *Scopes) NewField(commit *module.CommitInfo) (huh.Field, error) {
 
 	return huh.NewSelect[string]().
 		Options(typeOptions...).
-		Title("🙉・Select a Commit Scope").
-		Description("Additional contextual information about the changes.").
+		Title("🪱・Select a Commit Scope").
+		Description("Additional contextual information about the changes.\n").
 		Value(&commit.Scope), nil
 }
 

--- a/pkg/modules/types/types.go
+++ b/pkg/modules/types/types.go
@@ -44,8 +44,8 @@ func (s *Types) NewField(commit *module.CommitInfo) (huh.Field, error) {
 	}
 	return huh.NewSelect[string]().
 		Options(typeOptions...).
-		Title("🙈・Select a Commit Type").
-		Description("Folowing the Conventional Commits specification.").
+		Title("🪰・Select a Commit Type").
+		Description("Folowing the Conventional Commits specification.\n").
 		Value(&commit.Type), nil
 }
 

--- a/pkg/modules/why/why.go
+++ b/pkg/modules/why/why.go
@@ -23,7 +23,7 @@ func (w *Why) LoadConfig() error {
 // NewField returns a new Input field for the user to explain why the change was needed.
 func (w *Why) NewField(commit *module.CommitInfo) (huh.Field, error) {
 	return huh.NewInput().
-		Title("🤔・Why was this change needed?").
+		Title("❔・Why was this change needed?").
 		Description("Explain the reason for this change (max 100 chars).").
 		CharLimit(100).
 		Value(commit.Extras["why"]), nil


### PR DESCRIPTION
### Added Features

#### Pinned Modules

- **Functionality**: Modules can now be pinned to the top of every page, enhancing visibility and access.
- **Configuration**: Set the `Pinned` property to `true` in a module's configuration to activate this feature.

#### New Logo Module

- **Purpose**: Introduces a visually appealing ASCII art logo at the start of the goodcommit process, utilizing the pinned modules feature for consistent display.
- **Implementation**: Uses `huh.Note` for displaying ASCII art. Configured as active and pinned by default for optimal branding.

### Documentation Enhancements

- **Configuring Modules**: The `README.md` now includes a new section detailing how to configure modules. It outlines available fields (`name`, `page`, `position`, `pinned`, `active`, `path`, `priority`, `checkpoint`) and their impact on module behavior.
- **Examples Provided**: Demonstrates various configurations, such as basic module setup, pinning a module, and using external configuration files, to guide users in customizing the `goodcommit` form.

### Impact

This update improves the tool's flexibility and usability, allowing users to add things like branding and new workflows to the `goodcommit` form.
