### PR TITLE
feat: implement the 'signedoffby' module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Scaffold the initial CLI program with `huh` library. (#2)
+- Implement `type` and `scope` modules. (#3)
+- Implement pages and checkpoints functionality. (#4)
+- Add `greetings` module and enhance UX of existing modules. (#5)
+- Implement `co-authors`, `description`, `body`, and `why` modules. (#6)
+- Bring your own commiter functionality. (#6)
+- Pin modules functionality. (#8)
+- Add `logo` module. (#8)
+
+
+[unreleased]: https://github.com/nantli/goodcommit/compare/v0.0.0...HEAD

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nantli/goodcommit/pkg/modules/greetings"
 	"github.com/nantli/goodcommit/pkg/modules/logo"
 	"github.com/nantli/goodcommit/pkg/modules/scopes"
+	"github.com/nantli/goodcommit/pkg/modules/signedoffby"
 	"github.com/nantli/goodcommit/pkg/modules/types"
 	"github.com/nantli/goodcommit/pkg/modules/why"
 )
@@ -47,6 +48,7 @@ func main() {
 		description.New(),
 		breaking.New(),
 		coauthors.New(),
+		signedoffby.New(),
 	}
 
 	// Update modules with configuration

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -59,6 +59,10 @@
             "position": 1,
             "active": true,
             "path": "./configs/commit_coauthors.example.json"
+        },
+        {
+            "name": "signedoffby",
+            "active": true
         }
     ]
 }

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -17,7 +17,7 @@
             "name": "types",
             "page": 1,
             "position": 3,
-            "active": true,
+            "active": false,
             "path": "./configs/commit_types.example.json",
             "checkpoint": true
         },
@@ -62,7 +62,9 @@
         },
         {
             "name": "signedoffby",
-            "active": true
+            "active": true,
+            "page": 4,
+            "position": 3
         }
     ]
 }

--- a/pkg/commiters/goodcommiter/goodcommiter.go
+++ b/pkg/commiters/goodcommiter/goodcommiter.go
@@ -76,7 +76,11 @@ func (c *GoodCommiter) runForm(accessible bool) error {
 			if err != nil {
 				return err
 			}
-			fields = append(fields, field)
+
+			if field != nil {
+				fields = append(fields, field)
+			}
+
 		}
 
 		group := huh.NewGroup(fields...)
@@ -131,17 +135,13 @@ func (c *GoodCommiter) previewCommit() {
 	alertStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
 	footerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#00D4F4"))
 	fmt.Fprintf(&sb,
-		"%s\n\nType: %s\nScope: %s\n\n%s\n\n%s",
+		"%s\n\nType: %s\nScope: %s\nDescription: %s\nBody:\n\n%s",
 		lipgloss.NewStyle().Bold(true).Render("COMMIT SUMMARY 💎"),
 		keywordStyle.Render(c.commit.Type),
 		keywordStyle.Render(c.commit.Scope),
 		keywordStyle.Render(c.commit.Description),
 		lipgloss.NewStyle().Italic(true).Render(c.commit.Body),
 	)
-
-	if c.commit.Footer != "" {
-		fmt.Fprintf(&sb, "\n%s", keywordStyle.Render(c.commit.Footer))
-	}
 
 	if c.commit.Breaking {
 		fmt.Fprintf(&sb, "\n\n%s", alertStyle.Render("BREAKING CHANGE!"))
@@ -154,6 +154,10 @@ func (c *GoodCommiter) previewCommit() {
 			coauthors += fmt.Sprintf("\nCo-authored-by: %s", coauthor)
 		}
 		fmt.Fprintf(&sb, "\n%s", footerStyle.Render(coauthors))
+	}
+
+	if c.commit.Footer != "" {
+		fmt.Fprintf(&sb, "%s", footerStyle.Render(c.commit.Footer))
 	}
 
 	fmt.Fprintf(&sb, "\n\n%s", lipgloss.NewStyle().Bold(true).Render("He's alright, he's a GOODCOMMIT!"))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,11 +18,13 @@ type Config struct {
 // modules.
 func LoadConfigToModules(modules []module.Module) []module.Module {
 	var cfg Config
+
 	raw, err := os.ReadFile("./configs/config.example.json")
 	if err != nil {
 		fmt.Println("Error occurred while reading config:", err)
 		os.Exit(1)
 	}
+
 	err = json.Unmarshal(raw, &cfg)
 	if err != nil {
 		fmt.Println("Error occurred while parsing config:", err)
@@ -38,10 +40,6 @@ func LoadConfigToModules(modules []module.Module) []module.Module {
 					m.LoadConfig()
 				}
 			}
-			// drop modules that are not active
-			// if m.GetName() == mc.Name && !m.GetConfig().Active {
-			// 	modules = append(modules[:i], modules[i+1:]...)
-			// }
 		}
 	}
 	return modules

--- a/pkg/modules/description/description.go
+++ b/pkg/modules/description/description.go
@@ -30,6 +30,9 @@ func (d *Description) NewField(commit *module.CommitInfo) (huh.Field, error) {
 
 // PostProcess lowercases the first letter of the commit description.
 func (d *Description) PostProcess(commit *module.CommitInfo) error {
+	if commit.Description == "" {
+		return nil
+	}
 	commit.Description = strings.ToLower(commit.Description[:1]) + commit.Description[1:]
 	return nil
 }

--- a/pkg/modules/scopes/scope.go
+++ b/pkg/modules/scopes/scope.go
@@ -26,12 +26,12 @@ func (s *Scopes) LoadConfig() error {
 
 	raw, err := os.ReadFile(s.config.Path)
 	if err != nil {
-		fmt.Println("Error occurred while reading config:", err)
+		fmt.Println("Error occurred while reading scopes config:", err)
 		os.Exit(1)
 	}
 	err = json.Unmarshal(raw, &s)
 	if err != nil {
-		fmt.Println("Error occurred while parsing config:", err)
+		fmt.Println("Error occurred while parsing scopes config:", err)
 		os.Exit(1)
 	}
 

--- a/pkg/modules/signedoffby/signedoffby.go
+++ b/pkg/modules/signedoffby/signedoffby.go
@@ -1,0 +1,77 @@
+package signedoffby
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/module"
+)
+
+const MODULE_NAME = "signedoffby"
+
+type SignedOffBy struct {
+	config module.Config
+}
+
+func (s *SignedOffBy) LoadConfig() error {
+	// Load any necessary configuration. For this module, it might be inactive or active.
+	return nil
+}
+
+func (s *SignedOffBy) NewField(commit *module.CommitInfo) (huh.Field, error) {
+	// This module does not require input from the user.
+	return nil, nil
+}
+
+func (s *SignedOffBy) PostProcess(commit *module.CommitInfo) error {
+	// Execute the command to get the user's name from Git config
+	nameCmd := exec.Command("git", "config", "--get", "user.name")
+	var nameOut bytes.Buffer
+	nameCmd.Stdout = &nameOut
+	if err := nameCmd.Run(); err != nil {
+		return fmt.Errorf("failed to get git user name: %w", err)
+	}
+	authorName := nameOut.String()
+	authorName = authorName[:len(authorName)-1] // Remove the newline at the end
+
+	// Execute the command to get the user's email from Git config
+	emailCmd := exec.Command("git", "config", "--get", "user.email")
+	var emailOut bytes.Buffer
+	emailCmd.Stdout = &emailOut
+	if err := emailCmd.Run(); err != nil {
+		return fmt.Errorf("failed to get git user email: %w", err)
+	}
+	authorEmail := emailOut.String()
+	authorEmail = authorEmail[:len(authorEmail)-1] // Remove the newline at the end
+
+	// Append "Signed-off-by" to the commit footer with the gathered info
+	commit.Footer += fmt.Sprintf("\nSigned-off-by: %s <%s>", authorName, authorEmail)
+	return nil
+}
+
+func (s *SignedOffBy) GetConfig() module.Config {
+	return s.config
+}
+
+func (s *SignedOffBy) SetConfig(config module.Config) {
+	s.config = config
+}
+
+func (s *SignedOffBy) GetName() string {
+	return MODULE_NAME
+}
+
+func (s *SignedOffBy) IsActive() bool {
+	return s.config.Active
+}
+
+func (s *SignedOffBy) InitCommitInfo(commit *module.CommitInfo) error {
+	// Initialize any necessary fields in CommitInfo.
+	return nil
+}
+
+func New() module.Module {
+	return &SignedOffBy{}
+}

--- a/pkg/modules/types/types.go
+++ b/pkg/modules/types/types.go
@@ -24,12 +24,12 @@ func (s *Types) LoadConfig() error {
 
 	raw, err := os.ReadFile(s.config.Path)
 	if err != nil {
-		fmt.Println("Error occurred while reading config:", err)
+		fmt.Println("Error occurred while reading types config:", err)
 		os.Exit(1)
 	}
 	err = json.Unmarshal(raw, &s)
 	if err != nil {
-		fmt.Println("Error occurred while parsing config:", err)
+		fmt.Println("Error occurred while parsing types config:", err)
 		os.Exit(1)
 	}
 

--- a/pkg/modules/why/why.go
+++ b/pkg/modules/why/why.go
@@ -31,6 +31,10 @@ func (w *Why) NewField(commit *module.CommitInfo) (huh.Field, error) {
 
 // PostProcess prepends the value of the Why field to the commit body
 func (w *Why) PostProcess(commit *module.CommitInfo) error {
+	if commit.Extras["why"] == nil || *commit.Extras["why"] == "" {
+		return nil
+	}
+
 	commit.Body = fmt.Sprintf("%s\n\n%s", *commit.Extras["why"], commit.Body)
 	return nil
 }
@@ -48,7 +52,7 @@ func (w *Why) GetName() string {
 }
 
 func (w *Why) InitCommitInfo(commit *module.CommitInfo) error {
-	placeholder := "WHY: "
+	placeholder := ""
 	commit.Extras["why"] = &placeholder
 	return nil
 }


### PR DESCRIPTION
## PR Description: New Module - Commit Footer Sign-off

### Overview

This PR introduces the `signedoffby` module, designed to automate the inclusion of a "Signed-off-by" token in the footer of each commit message. This addition ensures that all commits carry an acknowledgment from the author, enhancing the integrity and traceability of contributions. Plus a CHANGELOG.md file was added (idea is to follow https://keepachangelog.com/en/1.1.0/).

### Implementation Details

- **Module Name:** `signedoffby`
- **Key Feature:** Automatic appending of `Signed-off-by` to the commit footer.
- **Activation:** Configurable via module settings; no user input required during the commit process.

### Changes Made

1. **New Module Implementation**: Created `signedoffby.go` in `pkg/modules/signedoffby`, implementing the module logic.
   
2. **Post-Processing Logic**:
   - Utilized `os/exec` to fetch the author's name and email from Git configuration.
   - Formatted and appended the "Signed-off-by" token to the commit footer.
