### PR TITLE
fix: pages showing only pinned modules are skipped

### DIFF
--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -17,7 +17,7 @@
             "name": "types",
             "page": 1,
             "position": 3,
-            "active": true,
+            "active": false,
             "path": "./configs/commit_types.example.json",
             "checkpoint": true
         },
@@ -25,7 +25,7 @@
             "name": "scopes",
             "page": 2,
             "position": 2,
-            "active": true,
+            "active": false,
             "path": "./configs/commit_scopes.example.json",
             "dependencies": ["types"]
         },

--- a/pkg/commiters/goodcommiter/goodcommiter.go
+++ b/pkg/commiters/goodcommiter/goodcommiter.go
@@ -56,6 +56,8 @@ func (c *GoodCommiter) runForm(accessible bool) error {
 	sort.Ints(pages) // Sort the pages
 
 	var groups []*huh.Group
+	pageHasNonPinned := make(map[int]bool) // Track if a page has non-pinned modules
+
 	for _, page := range pages { // Iterate over sorted pages
 		// Sort the modules by position
 		sort.Slice(modulesByPage[page], func(i, j int) bool {
@@ -72,19 +74,26 @@ func (c *GoodCommiter) runForm(accessible bool) error {
 		var fields []huh.Field
 		// Add the fields from the modules to the group
 		for _, m := range modulesByPage[page] {
+
 			field, err := (*m).NewField(&c.commit)
 			if err != nil {
 				return err
 			}
 
+			if !(*m).GetConfig().Pinned && field != nil && (*m).GetConfig().Active {
+				pageHasNonPinned[page] = true // Mark page as having non-pinned modules
+			}
+
 			if field != nil {
 				fields = append(fields, field)
 			}
-
 		}
 
-		group := huh.NewGroup(fields...)
-		groups = append(groups, group)
+		// Only create a group if the page has non-pinned modules
+		if pageHasNonPinned[page] {
+			group := huh.NewGroup(fields...)
+			groups = append(groups, group)
+		}
 
 		// Check if any module in the page has the checkpoint set to true
 		for _, m := range modulesByPage[page] {
@@ -105,6 +114,7 @@ func (c *GoodCommiter) runForm(accessible bool) error {
 			}
 		}
 	}
+
 	// Create and run the form with the remaining groups
 	form := huh.NewForm(groups...).
 		WithTheme(huh.ThemeCharm()).

--- a/pkg/commiters/goodcommiter/goodcommiter.go
+++ b/pkg/commiters/goodcommiter/goodcommiter.go
@@ -155,7 +155,7 @@ func (c *GoodCommiter) previewCommit() {
 
 	// Use the determined style for the commit type
 	fmt.Fprintf(&sb,
-		"%s\n\nType: %s\nScope: %s\nDescription: %s\nBody:\n\n%s",
+		"%s\n\nType: %s\nScope: %s\nDescription: %s\nBody:\n\n%s\n",
 		lipgloss.NewStyle().Bold(true).Render("COMMIT SUMMARY 💎"),
 		typeStyle.Render(c.commit.Type), // Apply the conditional styling here
 		keywordStyle.Render(c.commit.Scope),
@@ -169,7 +169,7 @@ func (c *GoodCommiter) previewCommit() {
 		for _, coauthor := range c.commit.CoAuthoredBy {
 			coauthors += fmt.Sprintf("\nCo-authored-by: %s", coauthor)
 		}
-		fmt.Fprintf(&sb, "\n%s", footerStyle.Render(coauthors))
+		fmt.Fprintf(&sb, "%s", footerStyle.Render(coauthors))
 	}
 
 	if c.commit.Footer != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,7 +44,7 @@ func LoadConfigToModules(modules []module.Module) ([]module.Module, error) {
 	// Second pass: Filter modules based on dependencies being met
 	for _, mc := range cfg.ModulesToActivate {
 		for _, m := range modules {
-			if m.GetName() == mc.Name {
+			if m.GetName() == mc.Name && mc.Active { // Ensure module is active before checking dependencies
 				// Check if all dependencies are met
 				allDependenciesMet := true
 				for _, dep := range mc.Dependencies {


### PR DESCRIPTION
## Summary
This PR introduces two bug fixes to the `goodcommit` form. Firstly, it addresses an issue where pages containing only pinned modules were unnecessarily displayed, streamlining the user experience by skipping such pages. Secondly, it fixes a bug where dependencies of inactive modules were being checked, leading to unmet dependency errors. The update ensures that only active modules have their dependencies checked, further enhancing the configuration process.

## Changes
- **Page Display Logic:** Introduced a map `pageHasNonPinned` to track whether a page has any non-pinned modules. Modified the form creation logic to check if a page has non-pinned modules before creating a group for that page. If a page only has pinned modules, it is now skipped, and no group is created for it.
- **Dependency Check Fix:** Updated the logic in `pkg/config/config.go` to only check the dependencies of modules marked as active in the configuration. This prevents unmet dependency errors for inactive modules, simplifying module management and configuration.

## WHY
- **Page Display Logic:** To enhance the user experience by avoiding unnecessary form pages that only display pinned modules, which do not require user interaction.
- **Dependency Check Fix:** This is the intended functionality.