### PR TITLE
feat: render and use commit message

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 )
 
 func main() {
+
 	var configPath string
 	flag.StringVar(&configPath, "config", "./configs/config.example.json", "Path to a configuration file")
 	flag.Parse()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ Flags:
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -38,6 +39,10 @@ import (
 )
 
 func main() {
+	var configPath string
+	flag.StringVar(&configPath, "config", "./configs/config.example.json", "Path to a configuration file")
+	flag.Parse()
+
 	accessible, _ := strconv.ParseBool(os.Getenv("ACCESSIBLE"))
 
 	// Load modules
@@ -56,7 +61,7 @@ func main() {
 	}
 
 	// Update modules with configuration
-	modules, err := config.LoadConfigToModules(modules)
+	modules, err := config.LoadConfigToModules(modules, configPath)
 	if err != nil {
 		fmt.Println("Error occurred while loading configuration:", err)
 		os.Exit(1)
@@ -77,7 +82,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Commit changes
+	// Commit changes, execute command
 	cmdStr := fmt.Sprintf("git commit -m \"%s\"", strings.ReplaceAll(message, "\"", "\\\""))
 	cmd := exec.Command("sh", "-c", cmdStr)
 	err = cmd.Run()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,7 +16,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/nantli/goodcommit/pkg/commiters/goodcommiter"
 	"github.com/nantli/goodcommit/pkg/config"
@@ -56,21 +58,31 @@ func main() {
 	// Update modules with configuration
 	modules, err := config.LoadConfigToModules(modules)
 	if err != nil {
-		fmt.Println("Error occurred:", err)
+		fmt.Println("Error occurred while loading configuration:", err)
 		os.Exit(1)
 	}
 
 	// Load the default goodcommiter (a goodcommit handler)
 	defaultCommiter, err := goodcommiter.New(modules)
 	if err != nil {
-		fmt.Println("Error occurred:", err)
+		fmt.Println("Error occurred while loading commiter:", err)
 		os.Exit(1)
 	}
 
 	// Load and execute goodcommit
 	gc := goodcommit.New(defaultCommiter)
-	if err := gc.Execute(accessible); err != nil {
-		fmt.Println("Error occurred:", err)
+	message, err := gc.Execute(accessible)
+	if err != nil {
+		fmt.Println("Error occurred while running goodcommit:", err)
+		os.Exit(1)
+	}
+
+	// Commit changes
+	cmdStr := fmt.Sprintf("git commit -m \"%s\"", strings.ReplaceAll(message, "\"", "\\\""))
+	cmd := exec.Command("sh", "-c", cmdStr)
+	err = cmd.Run()
+	if err != nil {
+		fmt.Printf("Error executing command: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/configs/commit_coauthors.example.json
+++ b/configs/commit_coauthors.example.json
@@ -6,14 +6,10 @@
         "emoji": "🫏"
       },
       {
-        "id": "bob@example.com",
-        "name": "Bob",
-        "emoji": "🦙"
-      },
-      {
-        "id": "carol@example.com",
-        "name": "Carol",
-        "emoji": "🏄‍♂️"
+        "id": "rola@hey.com",
+        "name": "Rolando Sotelo",
+        "emoji": "🦔"
       }
     ]
   }
+

--- a/configs/commit_scopes.example.json
+++ b/configs/commit_scopes.example.json
@@ -2,31 +2,25 @@
     "scopes": [
         {
             "id": "empty",
-            "emoji": "🦙",
+            "emoji": "🐜",
             "name": "Empty",
-            "description": "Use it for everything else",
+            "title": "",
+            "description": "Use this for everything else",
             "conditional": ["feat","fix", "chore"]
         },
         {
-            "id": "persistence",
-            "emoji": "🗄️",
-            "name": "Persistence",
-            "description": "Use this for tasks related to databases and other persistence layers",
+            "id": "commiters",
+            "emoji": "⛓️",
+            "name": "Commiters",
+            "description": "Use this when changes are made to commiters",
             "conditional": ["feat", "fix"]
         },
         {
-            "id": "performance",
-            "emoji": "🏎️",
-            "name": "Performance",
-            "description": "Use it for performance improvements",
-            "conditional": ["feat","fix"]
-        },
-        {
-            "id": "infrastructure",
-            "emoji": "🏗️",
-            "name": "Infrastructure",
-            "description": "Use this for anything related to infrastructure e.g. Terraform, Kubernetes",
-            "conditional": ["feat","fix"]
+            "id": "modules",
+            "emoji": "📦",
+            "name": "Modules",
+            "description": "Use this when changes are made to modules",
+            "conditional": ["feat", "fix"]
         },
         {
             "id": "wip",
@@ -34,6 +28,13 @@
             "name": "WIP",
             "description": "Use it when you need to commit but your work is still in progress",
             "conditional": ["feat","fix","chore"]
+        },
+        {
+            "id": "refactor",
+            "emoji": "🧰",
+            "name": "Refactor",
+            "description": "Use it when improving the codebase without adding new features or fixing bugs",
+            "conditional": ["chore"]
         },
         {
             "id": "dx",
@@ -47,13 +48,6 @@
             "emoji": "📚",
             "name": "Documentation",
             "description": "Use it for everything Documentation",
-            "conditional": ["chore"]
-        },
-        {
-            "id": "config",
-            "emoji": "🛠️",
-            "name": "Configuration",
-            "description": "Use it when modifying configuration files e.g. package.json",
             "conditional": ["chore"]
         }
     ]

--- a/configs/commit_scopes.example.json
+++ b/configs/commit_scopes.example.json
@@ -1,54 +1,25 @@
 {
     "scopes": [
         {
-            "id": "empty",
-            "emoji": "🐜",
-            "name": "Empty",
-            "title": "",
-            "description": "Use this for everything else",
-            "conditional": ["feat","fix", "chore"]
+            "id": "goodcommit",
+            "emoji": "🔫",
+            "name": "Goodcommit",
+            "description": "Use this when non of the other scopes appl",
+            "conditional": ["feat","fix","chore","refactor","docs"]
         },
         {
             "id": "commiters",
             "emoji": "⛓️",
             "name": "Commiters",
             "description": "Use this when changes are made to commiters",
-            "conditional": ["feat", "fix"]
+            "conditional": ["feat", "fix", "chore", "refactor", "docs"]
         },
         {
             "id": "modules",
             "emoji": "📦",
             "name": "Modules",
             "description": "Use this when changes are made to modules",
-            "conditional": ["feat", "fix"]
-        },
-        {
-            "id": "wip",
-            "emoji": "🚧",
-            "name": "WIP",
-            "description": "Use it when you need to commit but your work is still in progress",
-            "conditional": ["feat","fix","chore"]
-        },
-        {
-            "id": "refactor",
-            "emoji": "🧰",
-            "name": "Refactor",
-            "description": "Use it when improving the codebase without adding new features or fixing bugs",
-            "conditional": ["chore"]
-        },
-        {
-            "id": "dx",
-            "emoji": "💻",
-            "name": "Developer Experience",
-            "description": "Use it when improving the workflow for developers working on this repository",
-            "conditional": ["chore"]
-        },
-        {
-            "id": "documentation",
-            "emoji": "📚",
-            "name": "Documentation",
-            "description": "Use it for everything Documentation",
-            "conditional": ["chore"]
+            "conditional": ["feat", "fix", "chore", "refactor", "docs"]
         }
     ]
 }

--- a/configs/commit_scopes.example.json
+++ b/configs/commit_scopes.example.json
@@ -4,7 +4,7 @@
             "id": "goodcommit",
             "emoji": "🔫",
             "name": "Goodcommit",
-            "description": "Use this when non of the other scopes appl",
+            "description": "Use this when non of the other scopes apply",
             "conditional": ["feat","fix","chore","refactor","docs"]
         },
         {

--- a/configs/commit_types.example.json
+++ b/configs/commit_types.example.json
@@ -4,22 +4,32 @@
             "id": "feat",
             "name": "Feat",
             "emoji": "🌟",
-            "title": "New feature",
-            "description": "Correlates with MINOR in Semantic Versioning"
+            "title": "New commit introduces a new feature"
         },
         {
             "id": "fix",
             "name": "Fix",
             "emoji": "🐛",
-            "title": "This commit patches a bug",
-            "description": "Correlates with PATCH in Semantic Versioning"
+            "title": "This commit patches a bug"
+        },
+        {
+            "id": "refactor",
+            "name": "Refactor",
+            "emoji": "🧰",
+            "title": "Use this when improving the codebase"
+        },
+        {
+            "id": "docs",
+            "name": "Docs",
+            "emoji": "📝",
+            "title": "Use this when updating documentation"
         },
         {
             "id": "chore",
             "name": "Chore",
             "emoji": "🧰",
-            "title": "For all other tasks",
-            "description": "For commits not adding features nor fixing anything"
+            "title": "For all other tasks"
         }
     ]
 }
+

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -71,7 +71,8 @@
             "page": 5,
             "position": 1,
             "active": true,
-            "path": "./configs/commit_coauthors.example.json"
+            "path": "./configs/commit_coauthors.example.json",
+            "priority": 20
         },
         {
             "name": "signedoffby",

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -17,7 +17,7 @@
             "name": "types",
             "page": 1,
             "position": 3,
-            "active": false,
+            "active": true,
             "path": "./configs/commit_types.example.json",
             "checkpoint": true
         },
@@ -25,9 +25,10 @@
             "name": "scopes",
             "page": 2,
             "position": 2,
-            "active": false,
+            "active": true,
             "path": "./configs/commit_scopes.example.json",
-            "dependencies": ["types"]
+            "dependencies": ["types"],
+            "priority": 4
         },
         {
             "name": "description",
@@ -39,20 +40,22 @@
             "name": "why",
             "page": 3,
             "position": 2,
-            "active": true
+            "active": true,
+            "priority": 3
         },
         {
             "name": "body",
             "page": 3,
             "position": 3,
-            "active": true
+            "active": true,
+            "priority": 2
         },
         {
             "name": "breaking",
             "page": 3,
             "position": 4,
             "active": true,
-            "priority": 10,
+            "priority": 5,
             "checkpoint": true
         },
         {
@@ -60,7 +63,7 @@
             "page": 4,
             "position": 1,
             "active": true,
-            "priority": 10,
+            "priority": 6,
             "dependencies": ["breaking"]
         },
         {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 require (
 	github.com/charmbracelet/huh v0.3.0
 	github.com/charmbracelet/lipgloss v0.10.0
+	golang.org/x/text v0.13.0
 )
 
 require (
@@ -26,5 +27,4 @@ require (
 	golang.org/x/sync v0.4.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
 )

--- a/pkg/commit/commit.go
+++ b/pkg/commit/commit.go
@@ -1,0 +1,12 @@
+package commit
+
+type Config struct {
+	Type         string
+	Scope        string
+	Description  string
+	Body         string
+	Footer       string
+	Breaking     bool
+	CoAuthoredBy []string
+	Extras       map[string]*string
+}

--- a/pkg/commiter/commiter.go
+++ b/pkg/commiter/commiter.go
@@ -3,5 +3,8 @@
 package commiter
 
 type Commiter interface {
-	Execute(accessible bool) error
+	RunForm(accessible bool) error
+	RunPostProcessing() error
+	PreviewCommit()
+	RenderMessage() string
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,10 +16,10 @@ type Config struct {
 
 // LoadConfigToModules loads the configuration from the config file into the
 // modules.
-func LoadConfigToModules(modules []module.Module) ([]module.Module, error) {
+func LoadConfigToModules(modules []module.Module, configPath string) ([]module.Module, error) {
 	var cfg Config
 
-	raw, err := os.ReadFile("./configs/config.example.json")
+	raw, err := os.ReadFile(configPath)
 	if err != nil {
 		fmt.Println("Error occurred while reading config:", err)
 		os.Exit(1)

--- a/pkg/goodcommit/goodcommit.go
+++ b/pkg/goodcommit/goodcommit.go
@@ -12,6 +12,13 @@ func New(c commiter.Commiter) *GoodCommit {
 	return &GoodCommit{commiter: c}
 }
 
-func (g *GoodCommit) Execute(accessible bool) error {
-	return g.commiter.Execute(accessible)
+func (g *GoodCommit) Execute(accessible bool) (string, error) {
+	if err := g.commiter.RunForm(accessible); err != nil {
+		return "", err
+	}
+	if err := g.commiter.RunPostProcessing(); err != nil {
+		return "", err
+	}
+	g.commiter.PreviewCommit()
+	return g.commiter.RenderMessage(), nil
 }

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -1,6 +1,9 @@
 package module
 
-import "github.com/charmbracelet/huh"
+import (
+	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
+)
 
 type Config struct {
 	Page         int      `json:"page"`
@@ -25,22 +28,11 @@ type Item struct {
 
 type Module interface {
 	LoadConfig() error
-	NewField(commit *CommitInfo) (huh.Field, error)
-	PostProcess(commit *CommitInfo) error
+	NewField(commit *commit.Config) (huh.Field, error)
+	PostProcess(commit *commit.Config) error
 	GetConfig() Config
 	GetName() string
 	SetConfig(config Config)
-	InitCommitInfo(commit *CommitInfo) error
+	InitCommitInfo(commit *commit.Config) error
 	IsActive() bool
-}
-
-type CommitInfo struct {
-	Type         string
-	Scope        string
-	Description  string
-	Body         string
-	Footer       string
-	Breaking     bool
-	CoAuthoredBy []string
-	Extras       map[string]*string
 }

--- a/pkg/modules/body/body.go
+++ b/pkg/modules/body/body.go
@@ -1,7 +1,11 @@
 package body
 
 import (
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
 	"github.com/nantli/goodcommit/pkg/module"
 )
 
@@ -16,7 +20,7 @@ func (b *Body) LoadConfig() error {
 	return nil
 }
 
-func (b *Body) NewField(commit *module.CommitInfo) (huh.Field, error) {
+func (b *Body) NewField(commit *commit.Config) (huh.Field, error) {
 	return huh.NewText().
 		Title("📖・Write the Commit Body").
 		Description("Provide a more detailed description of the changes (ctrl+j creates a new line).").
@@ -24,8 +28,14 @@ func (b *Body) NewField(commit *module.CommitInfo) (huh.Field, error) {
 		Editor("vim"), nil
 }
 
-func (b *Body) PostProcess(commit *module.CommitInfo) error {
-	// No post-processing needed for this module.
+func (b *Body) PostProcess(commit *commit.Config) error {
+	// Capitalize first letter of body
+	caser := cases.Title(language.English)
+	commit.Body = caser.String(commit.Body[:1]) + commit.Body[1:]
+	// Add a period at the end of the body if it doesn't have one
+	if commit.Body[len(commit.Body)-1] != '.' {
+		commit.Body += "."
+	}
 	return nil
 }
 
@@ -41,7 +51,7 @@ func (b *Body) SetConfig(config module.Config) {
 	b.config = config
 }
 
-func (b *Body) InitCommitInfo(commit *module.CommitInfo) error {
+func (b *Body) InitCommitInfo(commit *commit.Config) error {
 	// No initialization needed for this module.
 	return nil
 }

--- a/pkg/modules/breaking/breaking.go
+++ b/pkg/modules/breaking/breaking.go
@@ -4,6 +4,7 @@ package breaking
 
 import (
 	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
 	"github.com/nantli/goodcommit/pkg/module"
 )
 
@@ -13,12 +14,12 @@ type Breaking struct {
 	config module.Config
 }
 
-func (s *Breaking) LoadConfig() error {
+func (b *Breaking) LoadConfig() error {
 	return nil
 }
 
 // NewField returns a new Confirm field for the user to indicate whether the commit introduces a breaking change.
-func (s *Breaking) NewField(commit *module.CommitInfo) (huh.Field, error) {
+func (b *Breaking) NewField(commit *commit.Config) (huh.Field, error) {
 
 	return huh.NewConfirm().
 		Title("☎️・Does this commit introduce a Breaking Change?").
@@ -28,26 +29,24 @@ func (s *Breaking) NewField(commit *module.CommitInfo) (huh.Field, error) {
 }
 
 // PostProcess adds ! symbol to commit type if the commit is a breaking change
-func (s *Breaking) PostProcess(commit *module.CommitInfo) error {
-	if commit.Breaking {
-		commit.Type = commit.Type + "!"
-	}
+func (b *Breaking) PostProcess(commit *commit.Config) error {
+
 	return nil
 }
 
-func (s *Breaking) GetConfig() module.Config {
-	return s.config
+func (b *Breaking) GetConfig() module.Config {
+	return b.config
 }
 
-func (s *Breaking) SetConfig(config module.Config) {
-	s.config = config
+func (b *Breaking) SetConfig(config module.Config) {
+	b.config = config
 }
 
-func (s *Breaking) GetName() string {
+func (b *Breaking) GetName() string {
 	return MODULE_NAME
 }
 
-func (s *Breaking) InitCommitInfo(commit *module.CommitInfo) error {
+func (b *Breaking) InitCommitInfo(commit *commit.Config) error {
 	// No initialization needed for this module.
 	return nil
 }

--- a/pkg/modules/breakingmsg/breakingmsg.go
+++ b/pkg/modules/breakingmsg/breakingmsg.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
 	"github.com/nantli/goodcommit/pkg/module"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const MODULE_NAME = "breakingmsg"
@@ -18,7 +21,7 @@ func (bm *BreakingMsg) LoadConfig() error {
 	return nil
 }
 
-func (bm *BreakingMsg) NewField(commit *module.CommitInfo) (huh.Field, error) {
+func (bm *BreakingMsg) NewField(commit *commit.Config) (huh.Field, error) {
 	// Only show this field if the commit is marked as breaking and not a chore
 	if commit.Breaking && commit.Type != "chore" {
 		return huh.NewText().
@@ -30,9 +33,16 @@ func (bm *BreakingMsg) NewField(commit *module.CommitInfo) (huh.Field, error) {
 	return nil, nil
 }
 
-func (bm *BreakingMsg) PostProcess(commit *module.CommitInfo) error {
+func (bm *BreakingMsg) PostProcess(commit *commit.Config) error {
 	if commit.Extras["breakingmsg"] == nil || *commit.Extras["breakingmsg"] == "" {
 		return nil
+	}
+	// Capitalize first letter of breaking message
+	caser := cases.Title(language.English)
+	*commit.Extras["breakingmsg"] = caser.String((*commit.Extras["breakingmsg"])[:1]) + (*commit.Extras["breakingmsg"])[1:]
+	// Add a period at the end of the breaking message if it doesn't have one
+	if (*commit.Extras["breakingmsg"])[len(*commit.Extras["breakingmsg"])-1] != '.' {
+		*commit.Extras["breakingmsg"] += "."
 	}
 	// At at the end of the Body, add a new line and the breaking message
 	commit.Body = fmt.Sprintf("%s\n\nBREAKING CHANGE: %s", commit.Body, *commit.Extras["breakingmsg"])
@@ -51,7 +61,7 @@ func (bm *BreakingMsg) GetName() string {
 	return MODULE_NAME
 }
 
-func (bm *BreakingMsg) InitCommitInfo(commit *module.CommitInfo) error {
+func (bm *BreakingMsg) InitCommitInfo(commit *commit.Config) error {
 	placeholder := ""
 	commit.Extras["breakingmsg"] = &placeholder
 	return nil

--- a/pkg/modules/coauthors/coauthors.go
+++ b/pkg/modules/coauthors/coauthors.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
 	"github.com/nantli/goodcommit/pkg/module"
 )
 
@@ -36,7 +37,7 @@ func (c *CoAuthors) LoadConfig() error {
 }
 
 // NewField returns a MultiSelect field with options for each co-author.
-func (c *CoAuthors) NewField(commit *module.CommitInfo) (huh.Field, error) {
+func (c *CoAuthors) NewField(commit *commit.Config) (huh.Field, error) {
 	var coAuthorOptions []huh.Option[string]
 	for _, item := range c.Items {
 		coAuthorOptions = append(coAuthorOptions, huh.NewOption(item.Name+" - "+item.Id, item.Name+" <"+item.Id+">"))
@@ -49,7 +50,7 @@ func (c *CoAuthors) NewField(commit *module.CommitInfo) (huh.Field, error) {
 		Value(&commit.CoAuthoredBy), nil
 }
 
-func (c *CoAuthors) PostProcess(commit *module.CommitInfo) error {
+func (c *CoAuthors) PostProcess(commit *commit.Config) error {
 	return nil
 }
 
@@ -65,7 +66,7 @@ func (c *CoAuthors) GetName() string {
 	return MODULE_NAME
 }
 
-func (c *CoAuthors) InitCommitInfo(commit *module.CommitInfo) error {
+func (c *CoAuthors) InitCommitInfo(commit *commit.Config) error {
 	// No initialization needed for this module.
 	return nil
 }

--- a/pkg/modules/description/description.go
+++ b/pkg/modules/description/description.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
 	"github.com/nantli/goodcommit/pkg/module"
 )
 
@@ -20,7 +21,7 @@ func (d *Description) LoadConfig() error {
 }
 
 // NewField returns a new Input field for the user to write a brief description of the commit (max 50 chars).
-func (d *Description) NewField(commit *module.CommitInfo) (huh.Field, error) {
+func (d *Description) NewField(commit *commit.Config) (huh.Field, error) {
 	return huh.NewInput().
 		Title("✏️・Write the Commit Description").
 		Description("Briefly describe the changes in this commit (max 50 chars).").
@@ -29,10 +30,11 @@ func (d *Description) NewField(commit *module.CommitInfo) (huh.Field, error) {
 }
 
 // PostProcess lowercases the first letter of the commit description.
-func (d *Description) PostProcess(commit *module.CommitInfo) error {
+func (d *Description) PostProcess(commit *commit.Config) error {
 	if commit.Description == "" {
 		return nil
 	}
+	commit.Description = strings.TrimSuffix(commit.Description, ".")
 	commit.Description = strings.ToLower(commit.Description[:1]) + commit.Description[1:]
 	return nil
 }
@@ -49,7 +51,7 @@ func (d *Description) GetName() string {
 	return MODULE_NAME
 }
 
-func (d *Description) InitCommitInfo(commit *module.CommitInfo) error {
+func (d *Description) InitCommitInfo(commit *commit.Config) error {
 	return nil
 }
 

--- a/pkg/modules/greetings/greetings.go
+++ b/pkg/modules/greetings/greetings.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 
 	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
 	"github.com/nantli/goodcommit/pkg/module"
 )
 
@@ -24,7 +25,7 @@ func (g *Greetings) LoadConfig() error {
 	return nil
 }
 
-func (g *Greetings) NewField(commit *module.CommitInfo) (huh.Field, error) {
+func (g *Greetings) NewField(commit *commit.Config) (huh.Field, error) {
 	stagedFiles, err := g.getStagedFiles()
 	if err != nil {
 		return nil, fmt.Errorf("error getting staged files: %w", err)
@@ -47,7 +48,7 @@ func (g *Greetings) NewField(commit *module.CommitInfo) (huh.Field, error) {
 	), nil
 }
 
-func (g *Greetings) PostProcess(commit *module.CommitInfo) error {
+func (g *Greetings) PostProcess(commit *commit.Config) error {
 	// This module does not modify the commit info, so no post-processing is needed.
 	return nil
 }
@@ -75,7 +76,7 @@ func (g *Greetings) getStagedFiles() (string, error) {
 	return out.String(), nil
 }
 
-func (g *Greetings) InitCommitInfo(commit *module.CommitInfo) error {
+func (g *Greetings) InitCommitInfo(commit *commit.Config) error {
 	return nil
 }
 

--- a/pkg/modules/logo/logo.go
+++ b/pkg/modules/logo/logo.go
@@ -2,6 +2,7 @@ package logo
 
 import (
 	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
 	"github.com/nantli/goodcommit/pkg/module"
 )
 
@@ -15,7 +16,7 @@ func (l *Logo) LoadConfig() error {
 	return nil
 }
 
-func (l *Logo) NewField(commit *module.CommitInfo) (huh.Field, error) {
+func (l *Logo) NewField(commit *commit.Config) (huh.Field, error) {
 	asciiArt := `                          
 		 ____ ____ ____ ____ ____ ____      
 		||N |||a |||n |||t |||l |||i ||     
@@ -28,7 +29,7 @@ func (l *Logo) NewField(commit *module.CommitInfo) (huh.Field, error) {
 	return huh.NewNote().Title(asciiArt), nil
 }
 
-func (l *Logo) PostProcess(commit *module.CommitInfo) error {
+func (l *Logo) PostProcess(commit *commit.Config) error {
 	// No post-processing needed for the Logo module.
 	return nil
 }
@@ -49,7 +50,7 @@ func (l *Logo) IsActive() bool {
 	return l.config.Active
 }
 
-func (l *Logo) InitCommitInfo(commit *module.CommitInfo) error {
+func (l *Logo) InitCommitInfo(commit *commit.Config) error {
 	return nil
 }
 

--- a/pkg/modules/signedoffby/signedoffby.go
+++ b/pkg/modules/signedoffby/signedoffby.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
 	"github.com/nantli/goodcommit/pkg/module"
 )
 
@@ -20,12 +21,12 @@ func (s *SignedOffBy) LoadConfig() error {
 	return nil
 }
 
-func (s *SignedOffBy) NewField(commit *module.CommitInfo) (huh.Field, error) {
+func (s *SignedOffBy) NewField(commit *commit.Config) (huh.Field, error) {
 	// This module does not require input from the user.
 	return nil, nil
 }
 
-func (s *SignedOffBy) PostProcess(commit *module.CommitInfo) error {
+func (s *SignedOffBy) PostProcess(commit *commit.Config) error {
 	// Execute the command to get the user's name from Git config
 	nameCmd := exec.Command("git", "config", "--get", "user.name")
 	var nameOut bytes.Buffer
@@ -67,7 +68,7 @@ func (s *SignedOffBy) IsActive() bool {
 	return s.config.Active
 }
 
-func (s *SignedOffBy) InitCommitInfo(commit *module.CommitInfo) error {
+func (s *SignedOffBy) InitCommitInfo(commit *commit.Config) error {
 	// Initialize any necessary fields in CommitInfo.
 	return nil
 }

--- a/pkg/modules/types/types.go
+++ b/pkg/modules/types/types.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
 	"github.com/nantli/goodcommit/pkg/module"
 )
 
@@ -16,18 +18,18 @@ type Types struct {
 	Items  []module.Item `json:"types"`
 }
 
-func (s *Types) LoadConfig() error {
+func (t *Types) LoadConfig() error {
 
-	if s.config.Path == "" {
+	if t.config.Path == "" {
 		return nil
 	}
 
-	raw, err := os.ReadFile(s.config.Path)
+	raw, err := os.ReadFile(t.config.Path)
 	if err != nil {
 		fmt.Println("Error occurred while reading types config:", err)
 		os.Exit(1)
 	}
-	err = json.Unmarshal(raw, &s)
+	err = json.Unmarshal(raw, &t)
 	if err != nil {
 		fmt.Println("Error occurred while parsing types config:", err)
 		os.Exit(1)
@@ -36,10 +38,10 @@ func (s *Types) LoadConfig() error {
 	return nil
 }
 
-func (s *Types) NewField(commit *module.CommitInfo) (huh.Field, error) {
+func (t *Types) NewField(commit *commit.Config) (huh.Field, error) {
 
 	var typeOptions []huh.Option[string]
-	for _, i := range s.Items {
+	for _, i := range t.Items {
 		typeOptions = append(typeOptions, huh.NewOption(i.Emoji+" "+i.Name+" - "+i.Title, i.Id))
 	}
 	return huh.NewSelect[string]().
@@ -49,19 +51,20 @@ func (s *Types) NewField(commit *module.CommitInfo) (huh.Field, error) {
 		Value(&commit.Type), nil
 }
 
-func (s *Types) PostProcess(commit *module.CommitInfo) error {
-	if commit.Type == "" && s.IsActive() {
+func (t *Types) PostProcess(commit *commit.Config) error {
+	if commit.Type == "" && t.IsActive() {
 		return fmt.Errorf("commit type is required")
 	}
+	commit.Type = strings.ToLower(commit.Type)
 	return nil
 }
 
-func (s *Types) GetConfig() module.Config {
-	return s.config
+func (t *Types) GetConfig() module.Config {
+	return t.config
 }
 
-func (s *Types) SetConfig(config module.Config) {
-	s.config = config
+func (t *Types) SetConfig(config module.Config) {
+	t.config = config
 }
 
 func (s *Types) Debug() error {
@@ -72,16 +75,16 @@ func (s *Types) Debug() error {
 	return nil
 }
 
-func (s *Types) GetName() string {
+func (t *Types) GetName() string {
 	return MODULE_NAME
 }
 
-func (s *Types) InitCommitInfo(commit *module.CommitInfo) error {
+func (t *Types) InitCommitInfo(commit *commit.Config) error {
 	return nil
 }
 
-func (s *Types) IsActive() bool {
-	return s.config.Active
+func (t *Types) IsActive() bool {
+	return t.config.Active
 }
 
 func New() module.Module {

--- a/pkg/modules/why/why.go
+++ b/pkg/modules/why/why.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/huh"
+	"github.com/nantli/goodcommit/pkg/commit"
 	"github.com/nantli/goodcommit/pkg/module"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const MODULE_NAME = "why"
@@ -21,7 +24,7 @@ func (w *Why) LoadConfig() error {
 }
 
 // NewField returns a new Input field for the user to explain why the change was needed.
-func (w *Why) NewField(commit *module.CommitInfo) (huh.Field, error) {
+func (w *Why) NewField(commit *commit.Config) (huh.Field, error) {
 	return huh.NewInput().
 		Title("❔・Why was this change needed?").
 		Description("Explain the reason for this change (max 100 chars).").
@@ -30,9 +33,16 @@ func (w *Why) NewField(commit *module.CommitInfo) (huh.Field, error) {
 }
 
 // PostProcess prepends the value of the Why field to the commit body
-func (w *Why) PostProcess(commit *module.CommitInfo) error {
+func (w *Why) PostProcess(commit *commit.Config) error {
 	if commit.Extras["why"] == nil || *commit.Extras["why"] == "" {
 		return nil
+	}
+	// Capitalize first letter of why
+	caser := cases.Title(language.English)
+	*commit.Extras["why"] = caser.String((*commit.Extras["why"])[:1]) + (*commit.Extras["why"])[1:]
+	// Add a period at the end of the why if it doesn't have one
+	if (*commit.Extras["why"])[len(*commit.Extras["why"])-1] != '.' {
+		*commit.Extras["why"] += "."
 	}
 
 	commit.Body = fmt.Sprintf("WHY: %s\n\n%s", *commit.Extras["why"], commit.Body)
@@ -51,7 +61,7 @@ func (w *Why) GetName() string {
 	return MODULE_NAME
 }
 
-func (w *Why) InitCommitInfo(commit *module.CommitInfo) error {
+func (w *Why) InitCommitInfo(commit *commit.Config) error {
 	placeholder := ""
 	commit.Extras["why"] = &placeholder
 	return nil


### PR DESCRIPTION
## Features

### Add Command Flag for Configuration File

Implemented the ability for the `goodcommit` CLI to accept a `--config` flag, allowing users to specify a custom path to the configuration file. This enhancement provides greater flexibility in managing different configurations for various projects or environments.

**Changes:**
- Added flag parsing in `cmd/main.go` to handle the `--config` flag.
- Modified `pkg/config/config.go` to accept the configuration path as an argument, enabling the use of custom configuration files.

### Add Author and Coauthors Emojis to the Body

Enhanced the commit message body by appending emojis for the author and coauthors. This feature adds a personal touch to the commit messages and makes them more engaging.

**Changes:**
- Updated `pkg/modules/coauthors/coauthors.go` to include emojis for the author and coauthors in the commit body.

### Render Commit Message for GoodCommiter

Implemented functionality in `GoodCommiter` to render the final commit message string according to the conventional commits standard. This feature ensures that the commit messages are consistent, readable, and follow best practices.

**Changes:**
- Modified `pkg/commiters/goodcommiter/goodcommiter.go` to build the commit message string following the conventional commits format.
