### PR TITLE
fix(📦): skip co-authors selection with 0 options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Use environment variable to set configuration file path, with `--config` flag taking precedence if both are provided. ([#14](https://github.com/nantli/goodcommit/pull/14))
 
+### Fixed
+
+- Skip co-authors selection when there are 0 options available. ([#15](https://github.com/nantli/goodcommit/pull/15))
+
 ## [1.0.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Use environment variable to set configuration file path, with `--config` flag taking precedence if both are provided. ([#14](https://github.com/nantli/goodcommit/pull/14))
+
 ## [1.0.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,11 +26,18 @@ To build `goodcommit`, ensure you have Go installed on your system. Then, follow
 
 ### Specifying a Configuration File
 
-To use a custom configuration file with `goodcommit`, specify the `--config` flag followed by the path to your configuration file (more details on configuration files below) when running the program:
+To use a custom configuration file with `goodcommit`, you have two options:
 
-```bash
-./goodcommit --config /path/to/your/config.json
-```
+1. **Using a Command Line Flag**: Specify the `--config` flag followed by the path to your configuration file when running the program:
+   ```bash
+   ./goodcommit --config /path/to/your/config.json
+   ```
+
+2. **Using an Environment Variable**: Set the `GOODCOMMIT_CONFIG_PATH` environment variable to the path of your configuration file. If both the environment variable and the `--config` flag are provided, the `--config` flag takes precedence.
+   ```bash
+   export GOODCOMMIT_CONFIG_PATH=/path/to/your/config.json
+   ./goodcommit
+   ```
 
 ## Developing New Modules
 

--- a/pkg/modules/coauthors/coauthors.go
+++ b/pkg/modules/coauthors/coauthors.go
@@ -50,18 +50,24 @@ func (c *CoAuthors) LoadConfig() error {
 // NewField returns a MultiSelect field with options for each co-author.
 func (c *CoAuthors) NewField(commit *commit.Config) (huh.Field, error) {
 
-	// use emailCmd := exec.Command("git", "config", "--get", "user.email") to filter the author from co-authors in c.Items
+	// Get the user's email
 	emailCmd := exec.Command("git", "config", "--get", "user.email")
 	email, err := emailCmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("error getting user email: %w", err)
 	}
 	userEmail := strings.TrimSpace(string(email))
+
+	// Filter out the user's email from the co-authors
 	coAuthors := []module.Item{}
 	for _, item := range c.Items {
 		if item.Id != userEmail {
 			coAuthors = append(coAuthors, item)
 		}
+	}
+
+	if len(coAuthors) == 0 {
+		return nil, nil
 	}
 
 	var coAuthorOptions []huh.Option[string]


### PR DESCRIPTION
SCOPE: Modules
WHY: No need to show it.

No field is built if the list of co-authors if empty.

🦔